### PR TITLE
Dockerize FE and API

### DIFF
--- a/harmony-api/.dockerignore
+++ b/harmony-api/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/harmony-api/Dockerfile
+++ b/harmony-api/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package*.json .
+
+RUN npm ci
+
+COPY . .
+
+EXPOSE 8081
+
+CMD [ "npm", "run", "start" ]

--- a/harmony-api/README.md
+++ b/harmony-api/README.md
@@ -15,3 +15,8 @@
 
 Run the command `npm run dev`.
 `harmony-api` is available at `localhost:8081`.
+
+### `harmony-api` Production Build
+
+1. Build the docker image using the command `docker build . -t harmony-api`
+2. Run the docker container using the command `docker run -p 8081:8081 harmony-api`

--- a/harmony-api/package.json
+++ b/harmony-api/package.json
@@ -10,10 +10,7 @@
   "scripts": {
     "lint": "gts lint",
     "clean": "gts clean",
-    "compile": "tsc",
     "fix": "gts fix",
-    "prepare": "npm run compile",
-    "pretest": "npm run compile",
     "posttest": "npm run lint",
     "start": "tsc && node build/src/index.js",
     "dev": "nodemon -L -w src -e ts --exec \"npm run start\""

--- a/harmony-fe/.dockerignore
+++ b/harmony-fe/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/harmony-fe/Dockerfile
+++ b/harmony-fe/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package*.json .
+
+RUN npm ci
+
+COPY . .
+
+EXPOSE 8080
+
+CMD [ "npm", "run", "start" ]

--- a/harmony-fe/README.md
+++ b/harmony-fe/README.md
@@ -15,3 +15,8 @@
 
 Run the command `npm run dev`
 `harmony-fe` is available at `localhost:8080`.
+
+### `harmony-fe` Production Build
+
+1. Build the docker image using the command `docker build . -t harmony-fe`
+2. Run the docker container using the command `docker run -p 8080:8080 harmony-fe`

--- a/harmony-fe/package.json
+++ b/harmony-fe/package.json
@@ -9,10 +9,7 @@
   "scripts": {
     "lint": "gts lint",
     "clean": "gts clean",
-    "compile": "tsc",
     "fix": "gts fix",
-    "prepare": "npm run compile",
-    "pretest": "npm run compile",
     "posttest": "npm run lint",
     "start": "next dev -p 8080",
     "dev": "nodemon -L -w src -e ts,tsx --exec \"npm run start\""


### PR DESCRIPTION
### Changes:

 - Removed some unused scripts from package.json in both FE and API since they caused problems in the docker build
 - Added `Dockerfile` files to FE and API
 - Updated `README.md` in FE and API to explain how to run a production build with docker

### Notes:

Looks like deleting the unused scripts in `package.json` solved the `npm install` issues. I see that @Developik posted a PR with another solution, but I think this is more robust. But I am open to discussion!

Also used `node:18-alpine` since it leads to a much smaller image size. The docker build runs in just a few seconds now!
