### PR TITLE
Fix seed connection string

### DIFF
--- a/harmony-api/prisma/seed/seed.sh
+++ b/harmony-api/prisma/seed/seed.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
 set -ex
 
-psql $POSTGRES_URL -f ./prisma/seed/dataset-seed/1_artist.sql
-psql $POSTGRES_URL -f ./prisma/seed/dataset-seed/2_artist_alias.sql
-psql $POSTGRES_URL -f ./prisma/seed/dataset-seed/3_artist_credit.sql
-psql $POSTGRES_URL -f ./prisma/seed/dataset-seed/4_artist_credit_relation.sql
-psql $POSTGRES_URL -f ./prisma/seed/dataset-seed/5_album.sql
-psql $POSTGRES_URL -f ./prisma/seed/dataset-seed/6_song.sql
-psql $POSTGRES_URL -f ./prisma/seed/dataset-seed/7_track.sql
-psql $POSTGRES_URL -f ./prisma/seed/dataset-seed/8_indexes.sql
+DB_CONNECTION_STRING="postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$DB_HOST:$POSTGRES_PORT/$POSTGRES_DB_NAME"
+
+psql $DB_CONNECTION_STRING -f ./prisma/seed/dataset-seed/1_artist.sql
+psql $DB_CONNECTION_STRING -f ./prisma/seed/dataset-seed/2_artist_alias.sql
+psql $DB_CONNECTION_STRING -f ./prisma/seed/dataset-seed/3_artist_credit.sql
+psql $DB_CONNECTION_STRING -f ./prisma/seed/dataset-seed/4_artist_credit_relation.sql
+psql $DB_CONNECTION_STRING -f ./prisma/seed/dataset-seed/5_album.sql
+psql $DB_CONNECTION_STRING -f ./prisma/seed/dataset-seed/6_song.sql
+psql $DB_CONNECTION_STRING -f ./prisma/seed/dataset-seed/7_track.sql
+psql $DB_CONNECTION_STRING -f ./prisma/seed/dataset-seed/8_indexes.sql


### PR DESCRIPTION
### Changes:
 - `$POSTGRES_URL` contains query params in prod. Those will not work with the `psql` command line tool. We must build the connection string in the seed script.